### PR TITLE
Suggest alternative installation method for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ pip install numpy
 pip install git+https://github.com/sequitur-g2p/sequitur-g2p@master
 ```
 
+Note, when installing on MacOS, you might run into issues due to the default 
+libc being clang's one. If that is the case, try installing it with:
+```
+CPPFLAGS="-stdlib=libstdc++" pip install git+https://github.com/sequitur-g2p/sequitur-g2p@master
+```
+
 
 Using
 -----


### PR DESCRIPTION
It took me two days fighting this thing. Could not install it on MacOS using `pip` nor building from source. Then I ran into https://github.com/kaldi-asr/kaldi/issues/1107 which solved my issue. Thought it might help others in the future if that bit of knowledge is here in the repo.