### PR TITLE
Fixing compilation issues in xcode and compatibility with clang

### DIFF
--- a/Estimation.cc
+++ b/Estimation.cc
@@ -27,7 +27,7 @@
 
 #include "Python.hh"  // Must be first to prevent some warnings
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
 #include <unordered_map>
 using std::unordered_map;
 #else
@@ -222,7 +222,7 @@ class EvidenceStore {
     SequenceModelEstimator *makeSequenceModelEstimator() const;
 
     size_t memoryUsed() const {
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
       struct StoreNode { typename Store::value_type value; bool cond;};
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
       typedef std::tr1::__detail::_Hash_node<Store::value_type, false> StoreNode;
@@ -629,7 +629,7 @@ class EstimationGraphBuilder :
     }
 
     size_t memoryUsed() const {
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
       struct NodeStateMapNode { typename NodeStateMap::value_type value; bool cond;};
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
       typedef std::tr1::__detail::_Hash_node<NodeStateMap::value_type, false> NodeStateMapNode;
@@ -738,7 +738,7 @@ void SequenceModelEstimator::makeSequenceModel(
   doKneserNeyDiscounting(discounts);
   computeProbabilities(vocabularySize);
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
   std::shared_ptr<SequenceModel::InitData> data(new SequenceModel::InitData);
   //std::unique_ptr<SequenceModel::InitData> data;
   //data = std::move(new SequenceModel::InitData);

--- a/Multigram.hh
+++ b/Multigram.hh
@@ -6,7 +6,7 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License Version 2 (June
  * 1991) as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -30,7 +30,7 @@
 #include "Python.hh"
 
 #include <vector>
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
 #include <unordered_map>
 using std::unordered_map;
 #else
@@ -171,7 +171,7 @@ class MultigramInventory {
     }
 
     size_t memoryUsed() const {
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) 
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
       struct MapNode { Map::value_type value; bool cond;};
 #elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
       typedef std::tr1::__detail::_Hash_node<Map::value_type, false> MapNode;

--- a/PriorityQueue.hh
+++ b/PriorityQueue.hh
@@ -6,7 +6,7 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License Version 2 (June
  * 1991) as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,7 +28,7 @@
 #ifndef _CORE_PRIORITY_QUEUE_HH
 #define _CORE_PRIORITY_QUEUE_HH
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
 #include <unordered_map>
 using std::unordered_map;
 #define stdhash std::hash
@@ -38,13 +38,34 @@ using std::tr1::unordered_map;
 #define stdhash std::tr1::hash
 #endif
 #include <functional>
-#include <ext/functional>
+//#include <ext/functional>
+
 
 #include "Assertions.hh"
 #include "Types.hh"
 
 
 namespace Core {
+
+template< typename P >
+struct select1st
+{
+   typename P::first_type const& operator()( P const& p ) const
+   {
+       return p.first;
+   }
+};
+
+template< typename P >
+struct select2nd
+{
+   typename P::second_type const& operator()( P const& p ) const
+   {
+       return p.second;
+   }
+};
+
+
 
   template <class T_Heap, class T_PriorityFunction>
     class PriorityQueueBase :
@@ -236,9 +257,9 @@ namespace Core {
    * Heap-based priority queue class template with random access.
    */
   // the lambda version:
-  template <class T_Item, class T_Key = typename T_Item::first_type, class T_KeyFunction = __gnu_cxx::select1st<T_Item>,
+  template <class T_Item, class T_Key = typename T_Item::first_type, class T_KeyFunction = select1st<T_Item>,
            class T_PriorityFunction = std::binary_function<std::less<typename T_Item::second_type>,
-           __gnu_cxx::select2nd<T_Item>, __gnu_cxx::select2nd<T_Item> >,
+           select2nd<T_Item>, select2nd<T_Item> >,
            class T_Hash_Obj = stdhash<T_Key> >
              class TracedPriorityQueue :
                public PriorityQueueBase<

--- a/SequenceModel.cc
+++ b/SequenceModel.cc
@@ -463,7 +463,7 @@ void SequenceModel::set(PyObject *obj) {
   if (!PySequence_Check(obj))
     throw PythonException(PyExc_TypeError, "not a sequence");
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
   std::shared_ptr<InitData> data(new InitData);
 #else
   std::auto_ptr<InitData> data(new InitData);

--- a/Translation.cc
+++ b/Translation.cc
@@ -27,7 +27,7 @@
 
 #include "Python.hh"  // Must be first to prevent some warnings
 
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L) || (__APPLE__)
 #include <unordered_map>
 using std::unordered_multimap;
 using std::unordered_map;

--- a/Utility.hh
+++ b/Utility.hh
@@ -6,7 +6,7 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License Version 2 (June
  * 1991) as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -291,14 +291,5 @@ namespace Core {
 
 } // namespace Core
 
-
-/**
- * This seems to be obsolete for GCC >= 3.3.4
- */
-#include <functional>
-namespace std {
-    template <class _Pair> struct select1st : public std::_Select1st<_Pair> {};
-    template <class _Pair> struct select2nd : public std::_Select2nd<_Pair> {};
-}
 
 #endif // _CORE_UTILITY_HH


### PR DESCRIPTION
For some unknown reason, Apple's clang/g++ stub does not set __cplusplus  >= 201103L albeit it does not support TR1 anymore.

Moreover, this PR gets rid of the dependence on GCC's ext/functional (select1st and select2nd)
which does not exist in clang (and probably any other compiler).

I'm leaving it open for some time so that anyone can comment or test