### PR TITLE
Fixed --apply in python3. Need to use sys.stdout.buffer to write bytes.

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -218,7 +218,10 @@ import gzip, errno, os, sys, io, codecs
 
 def gOpenOut(fname, encoding=None):
     if fname == '-':
-        out = sys.stdout
+        if hasattr(sys.stdout, 'buffer'):
+            out = sys.stdout.buffer
+        else:
+            out = sys.stdout
     elif os.path.splitext(fname)[1] == '.gz':
         out = os.popen('gzip -fc >%s' % fname, 'w')
 #       out = gzip.open(fname, 'w')


### PR DESCRIPTION
We ran into an issue recently that we could not use g2p.py --apply in python3. This should fix the issue but there are most likely more places in the codebase where this could be an issue.