### PR TITLE
Add numpy as a build dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.14.2"]


### PR DESCRIPTION
Adding numpy as a build dependency in pyproject.toml makes it possible to use
the git repo as a pip requirement. E.g.

  pip install git+https://github.com/sequitur-g2p/sequitur-g2p@master