### PR TITLE
Fix setup install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-__author__ = "Maximilian Bisani"
-__version__ = "$LastChangedRevision: 1691 $"
-__date__ = "$LastChangedDate: 2011-08-03 15:38:08 +0200 (Wed, 03 Aug 2011) $"
-__copyright__ = "Copyright (c) 2004-2005  RWTH Aachen University"
+__author__ = 'Maximilian Bisani'
+__version__ = '$LastChangedRevision: 1691 $'
+__date__ = '$LastChangedDate: 2011-08-03 15:38:08 +0200 (Wed, 03 Aug 2011) $'
+__copyright__ = 'Copyright (c) 2004-2005  RWTH Aachen University'
 __license__ = """
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License Version 2 (June
@@ -31,13 +31,13 @@ import numpy
 from setuptools import setup, Extension
 from setuptools.command.build_py import build_py as _build_py
 
-VERSION = "1.0.1668.6"
+VERSION = '1.0.1668.6'
 
-with open("requirements.txt") as fp:
+with open('requirements.txt') as fp:
     required = fp.read().splitlines()
 
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 
@@ -45,59 +45,59 @@ class build_py(_build_py):
     """Build SWIG extension before Python modules."""
 
     def run(self):
-        self.run_command("build_ext")
+        self.run_command('build_ext')
         return _build_py.run(self)
 
 
 sequiturExtension = Extension(
-    "_sequitur_",
-    language="c++",
-    define_macros=[("MULTIGRAM_SIZE", "4")],
+    '_sequitur_',
+    language='c++',
+    define_macros=[('MULTIGRAM_SIZE', '4')],
     sources=[
-        "sequitur.i",
-        "Assertions.cc",
-        "Types.cc",
-        "Utility.cc",
-        "Graph.cc",
-        "Multigram.cc",
+        'sequitur.i',
+        'Assertions.cc',
+        'Types.cc',
+        'Utility.cc',
+        'Graph.cc',
+        'Multigram.cc',
     ],
     depends=[
-        "Assertions.hh",
-        "Graph.hh",
-        "Multigram.hh",
-        "MultigramGraph.hh",
-        "Multigram.hh",
-        "Obstack.hh",
-        "PriorityQueue.hh",
-        "Probability.hh",
-        "Python.hh",
-        "ReferenceCounting.hh",
-        "SequenceModel.hh",
-        "Types.hh",
-        "Utility.hh",
-        "EditDistance.cc",
-        "Estimation.cc",
-        "SequenceModel.cc",
-        "Translation.cc",
+        'Assertions.hh',
+        'Graph.hh',
+        'Multigram.hh',
+        'MultigramGraph.hh',
+        'Multigram.hh',
+        'Obstack.hh',
+        'PriorityQueue.hh',
+        'Probability.hh',
+        'Python.hh',
+        'ReferenceCounting.hh',
+        'SequenceModel.hh',
+        'Types.hh',
+        'Utility.hh',
+        'EditDistance.cc',
+        'Estimation.cc',
+        'SequenceModel.cc',
+        'Translation.cc',
     ],
-    include_dirs=[os.path.join(path, "core/include") for path in numpy.__path__],
-    extra_compile_args=["-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION"],
+    include_dirs=[os.path.join(path, 'core/include') for path in numpy.__path__],
+    extra_compile_args=['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],
 )
 
 sequiturModules = [
-    "Evaluation",
-    "Minimization",
-    "SequenceModel",
-    "SequiturTool",
-    "g2p",
-    "misc",
-    "sequitur",
-    "sequitur_",
-    "symbols",
-    "tool",
+    'Evaluation',
+    'Minimization',
+    'SequenceModel',
+    'SequiturTool',
+    'g2p',
+    'misc',
+    'sequitur',
+    'sequitur_',
+    'symbols',
+    'tool',
 ]
 
-sequiturScripts = ["g2p.py"]
+sequiturScripts = ['g2p.py']
 
 
 #  os.system('pyrexc SparseVector.pyx')
@@ -105,51 +105,51 @@ sequiturScripts = ["g2p.py"]
 #  os.system('pyrexc IntTuple.pyx')
 #  intTupleExtension = Extension('IntTuple', ['IntTuple.c'])
 lmModules = [
-    "IterMap",
-    "mGramCounts",
-    "groupedCounts",
-    "SimpleGoodTuring",
-    "LanguageModel",
-    "makeOvModel",
+    'IterMap',
+    'mGramCounts',
+    'groupedCounts',
+    'SimpleGoodTuring',
+    'LanguageModel',
+    'makeOvModel',
 ]
-lmScripts = ["makeOvModel.py"]
+lmScripts = ['makeOvModel.py']
 
 
 setup(
-    name="sequitur-g2p",
+    name='sequitur-g2p',
     version=VERSION,
-    license="gpl-2.0",
-    description="sequence and joint-sequence modelling tool for g2p",
-    keywords="g2p grapheme-to-phoneme sequitur grapheme phoneme",
+    license='gpl-2.0',
+    description='sequence and joint-sequence modelling tool for g2p',
+    keywords='g2p grapheme-to-phoneme sequitur grapheme phoneme',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Maximilian Bisani",
-    maintainer="Jan 'Yenda' Trmal",
-    maintainer_email="jtrmal@gmail.com",
-    url="https://github.com/sequitur-g2p/sequitur-g2p",
+    long_description_content_type='text/markdown',
+    author='Maximilian Bisani',
+    maintainer='Jan 'Yenda' Trmal',
+    maintainer_email='jtrmal@gmail.com',
+    url='https://github.com/sequitur-g2p/sequitur-g2p',
     project_urls={
-        "Original site": "https://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html",
-        "Bug Tracker": "https://github.com/sequitur-g2p/sequitur-g2p/issues",
+        'Original site': 'https://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html',
+        'Bug Tracker': 'https://github.com/sequitur-g2p/sequitur-g2p/issues',
     },
-    cmdclass={"build_py": build_py},
+    cmdclass={'build_py': build_py},
     install_requires=required,
     py_modules=sequiturModules,
     ext_modules=[sequiturExtension],
     scripts=sequiturScripts,
     classifiers=[
-        "Development Status :: 6 - Mature",
-        "Environment :: Console",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-        "Topic :: Scientific/Engineering",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        'Development Status :: 6 - Mature',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
-    python_requires=">=2.7.0",
+    python_requires='>=2.7.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class build_py(_build_py):
 
     def run(self):
         self.run_command("build_ext")
-        return super().run()
+        return _build_py.run(self)
 
 
 sequiturExtension = Extension(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-__author__ = 'Maximilian Bisani'
-__version__ = '$LastChangedRevision: 1691 $'
-__date__ = '$LastChangedDate: 2011-08-03 15:38:08 +0200 (Wed, 03 Aug 2011) $'
-__copyright__ = 'Copyright (c) 2004-2005  RWTH Aachen University'
+__author__ = "Maximilian Bisani"
+__version__ = "$LastChangedRevision: 1691 $"
+__date__ = "$LastChangedDate: 2011-08-03 15:38:08 +0200 (Wed, 03 Aug 2011) $"
+__copyright__ = "Copyright (c) 2004-2005  RWTH Aachen University"
 __license__ = """
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License Version 2 (June
@@ -28,13 +28,12 @@ negligent actions or intended actions or fraudulent concealment.
 import os
 import numpy
 
-from distutils.command.build import build
 from setuptools import setup, Extension
+from setuptools.command.build_py import build_py as _build_py
 
+VERSION = "1.0.1668.6"
 
-VERSION = '1.0.1668.6'
-
-with open('requirements.txt') as fp:
+with open("requirements.txt") as fp:
     required = fp.read().splitlines()
 
 
@@ -42,66 +41,63 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 
-class CustomBuild(build):
-    """Custom build class to swig before handling python modules."""
-    sub_commands = [
-        ('build_ext', build.has_ext_modules),
-        ('build_py', build.has_pure_modules),
-        ('build_clib', build.has_c_libraries),
-        ('build_scripts', build.has_scripts)
-    ]
+class build_py(_build_py):
+    """Build SWIG extension before Python modules."""
+
+    def run(self):
+        self.run_command("build_ext")
+        return super().run()
 
 
 sequiturExtension = Extension(
-    '_sequitur_',
-    language='c++',
-    define_macros=[
-        ('MULTIGRAM_SIZE', '4')],
+    "_sequitur_",
+    language="c++",
+    define_macros=[("MULTIGRAM_SIZE", "4")],
     sources=[
-        'sequitur.i',
-        'Assertions.cc',
-        'Types.cc',
-        'Utility.cc',
-        'Graph.cc',
-        'Multigram.cc'],
+        "sequitur.i",
+        "Assertions.cc",
+        "Types.cc",
+        "Utility.cc",
+        "Graph.cc",
+        "Multigram.cc",
+    ],
     depends=[
-        'Assertions.hh',
-        'Graph.hh',
-        'Multigram.hh',
-        'MultigramGraph.hh',
-        'Multigram.hh',
-        'Obstack.hh',
-        'PriorityQueue.hh',
-        'Probability.hh',
-        'Python.hh',
-        'ReferenceCounting.hh',
-        'SequenceModel.hh',
-        'Types.hh',
-        'Utility.hh',
-        'EditDistance.cc',
-        'Estimation.cc',
-        'SequenceModel.cc',
-        'Translation.cc'],
-    include_dirs=[
-        os.path.join(path, 'core/include') for path in numpy.__path__],
-    extra_compile_args=[
-        '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
+        "Assertions.hh",
+        "Graph.hh",
+        "Multigram.hh",
+        "MultigramGraph.hh",
+        "Multigram.hh",
+        "Obstack.hh",
+        "PriorityQueue.hh",
+        "Probability.hh",
+        "Python.hh",
+        "ReferenceCounting.hh",
+        "SequenceModel.hh",
+        "Types.hh",
+        "Utility.hh",
+        "EditDistance.cc",
+        "Estimation.cc",
+        "SequenceModel.cc",
+        "Translation.cc",
+    ],
+    include_dirs=[os.path.join(path, "core/include") for path in numpy.__path__],
+    extra_compile_args=["-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION"],
 )
 
 sequiturModules = [
-    'Evaluation',
-    'Minimization',
-    'SequenceModel',
-    'SequiturTool',
-    'g2p',
-    'misc',
-    'sequitur',
-    'sequitur_',
-    'symbols',
-    'tool']
+    "Evaluation",
+    "Minimization",
+    "SequenceModel",
+    "SequiturTool",
+    "g2p",
+    "misc",
+    "sequitur",
+    "sequitur_",
+    "symbols",
+    "tool",
+]
 
-sequiturScripts = [
-    'g2p.py']
+sequiturScripts = ["g2p.py"]
 
 
 #  os.system('pyrexc SparseVector.pyx')
@@ -109,33 +105,33 @@ sequiturScripts = [
 #  os.system('pyrexc IntTuple.pyx')
 #  intTupleExtension = Extension('IntTuple', ['IntTuple.c'])
 lmModules = [
-    'IterMap',
-    'mGramCounts',
-    'groupedCounts',
-    'SimpleGoodTuring',
-    'LanguageModel',
-    'makeOvModel']
-lmScripts = [
-    'makeOvModel.py']
+    "IterMap",
+    "mGramCounts",
+    "groupedCounts",
+    "SimpleGoodTuring",
+    "LanguageModel",
+    "makeOvModel",
+]
+lmScripts = ["makeOvModel.py"]
 
 
 setup(
-    name='sequitur-g2p',
+    name="sequitur-g2p",
     version=VERSION,
-    license='gpl-2.0',
-    description='sequence and joint-sequence modelling tool for g2p',
+    license="gpl-2.0",
+    description="sequence and joint-sequence modelling tool for g2p",
     keywords="g2p grapheme-to-phoneme sequitur grapheme phoneme",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author='Maximilian Bisani',
+    author="Maximilian Bisani",
     maintainer="Jan 'Yenda' Trmal",
-    maintainer_email='jtrmal@gmail.com',
-    url='https://github.com/sequitur-g2p/sequitur-g2p',
+    maintainer_email="jtrmal@gmail.com",
+    url="https://github.com/sequitur-g2p/sequitur-g2p",
     project_urls={
         "Original site": "https://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html",
         "Bug Tracker": "https://github.com/sequitur-g2p/sequitur-g2p/issues",
     },
-    cmdclass={'build': CustomBuild},
+    cmdclass={"build_py": build_py},
     install_requires=required,
     py_modules=sequiturModules,
     ext_modules=[sequiturExtension],
@@ -147,13 +143,13 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering",
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
-    python_requires='>=2.7.0',
+    python_requires=">=2.7.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open('requirements.txt') as fp:
     required = fp.read().splitlines()
 
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 
@@ -82,7 +82,7 @@ sequiturExtension = Extension(
     include_dirs=[
         os.path.join(path, 'core/include') for path in numpy.__path__],
     extra_compile_args=[
-        '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],
+        '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
 )
 
 sequiturModules = [
@@ -111,8 +111,7 @@ lmModules = [
     'groupedCounts',
     'SimpleGoodTuring',
     'LanguageModel',
-    'makeOvModel',
-]
+    'makeOvModel']
 lmScripts = [
     'makeOvModel.py']
 

--- a/setup.py
+++ b/setup.py
@@ -52,15 +52,15 @@ class build_py(_build_py):
 sequiturExtension = Extension(
     '_sequitur_',
     language='c++',
-    define_macros=[('MULTIGRAM_SIZE', '4')],
+    define_macros=[
+        ('MULTIGRAM_SIZE', '4')],
     sources=[
         'sequitur.i',
         'Assertions.cc',
         'Types.cc',
         'Utility.cc',
         'Graph.cc',
-        'Multigram.cc',
-    ],
+        'Multigram.cc'],
     depends=[
         'Assertions.hh',
         'Graph.hh',
@@ -78,10 +78,11 @@ sequiturExtension = Extension(
         'EditDistance.cc',
         'Estimation.cc',
         'SequenceModel.cc',
-        'Translation.cc',
-    ],
-    include_dirs=[os.path.join(path, 'core/include') for path in numpy.__path__],
-    extra_compile_args=['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],
+        'Translation.cc'],
+    include_dirs=[
+        os.path.join(path, 'core/include') for path in numpy.__path__],
+    extra_compile_args=[
+        '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],
 )
 
 sequiturModules = [
@@ -94,10 +95,10 @@ sequiturModules = [
     'sequitur',
     'sequitur_',
     'symbols',
-    'tool',
-]
+    'tool']
 
-sequiturScripts = ['g2p.py']
+sequiturScripts = [
+    'g2p.py']
 
 
 #  os.system('pyrexc SparseVector.pyx')
@@ -112,7 +113,8 @@ lmModules = [
     'LanguageModel',
     'makeOvModel',
 ]
-lmScripts = ['makeOvModel.py']
+lmScripts = [
+    'makeOvModel.py']
 
 
 setup(
@@ -120,16 +122,16 @@ setup(
     version=VERSION,
     license='gpl-2.0',
     description='sequence and joint-sequence modelling tool for g2p',
-    keywords='g2p grapheme-to-phoneme sequitur grapheme phoneme',
+    keywords="g2p grapheme-to-phoneme sequitur grapheme phoneme",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author='Maximilian Bisani',
-    maintainer='Jan 'Yenda' Trmal',
+    maintainer="Jan 'Yenda' Trmal",
     maintainer_email='jtrmal@gmail.com',
     url='https://github.com/sequitur-g2p/sequitur-g2p',
     project_urls={
-        'Original site': 'https://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html',
-        'Bug Tracker': 'https://github.com/sequitur-g2p/sequitur-g2p/issues',
+        "Original site": "https://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html",
+        "Bug Tracker": "https://github.com/sequitur-g2p/sequitur-g2p/issues",
     },
     cmdclass={'build_py': build_py},
     install_requires=required,
@@ -137,12 +139,12 @@ setup(
     ext_modules=[sequiturExtension],
     scripts=sequiturScripts,
     classifiers=[
-        'Development Status :: 6 - Mature',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
-        'Operating System :: OS Independent',
-        'Topic :: Scientific/Engineering',
+        "Development Status :: 6 - Mature",
+        "Environment :: Console",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering",
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I ran into problems when calling `python setup.py install` as part of an effort to create a conda package out of sequitur-g2p. For some reason `sequitur_.py` which is generated by SWIG wasn't included in the package.

It seems that building the SWIG extension generated python module for some reason wasn't done in the correct order. This is likely because the order was only fixed for the "build" command but not the "install" command inside setup.py.

Instead of changing the order for the whole build command, I followed https://stackoverflow.com/questions/29477298/setup-py-run-build-ext-before-anything-else/48942866#48942866 and modify that step for building python modules to first call the extension.

I tested that `pip install git+https://github.com/sequitur-g2p/sequitur-g2p@master` would still work for python2.7 and 3.6 and newer.

Sorry about the changes to the quoting done by the formatter. I could revert these if desired.