### PR TITLE
Setup publishing wheels through GitHub actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,62 @@
+---
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+on: [push]
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      PKG_NAME: sequitur-g2p
+      CIBW_BUILD: "cp3*win* cp3*manylinux* cp3*mac*"
+      CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="10.9" CC="clang++" CXX="clang++" CFLAGS="-std=c++11 -stdlib=libc++" CXXFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++"
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+      CIBW_MANYLINUX_I686_IMAGE: manylinux1
+      TEST: true
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          wget -O - https://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz | tar xzf -
+          cd swig-4.0.1 && ./configure --without-pcre && make && sudo make install
+      - if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          choco install swig
+      - if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          brew update
+          brew install swig
+      - run: python -m pip install build
+      - run: pip install -r requirements.txt
+      - run: pip install -r dev-requirements.txt
+      - run: pip install .
+      - run: make travis-test
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel --outdir dist/ .
+      - run: ls -alR dist/
+        shell: bash {0}
+        # TODO: auditwheel doesn't like our compiler; need to switch to Docker
+        # - if: ${{ matrix.os == 'ubuntu-20.04' }}
+        #   run: |
+        #     for whl in dist/sequitur*.whl; do
+        #       auditwheel repair "$whl" --plat manylinux1_x86_64 -w dist/;
+        #     done
+        # TODO: publish to PyPI
+        # - name: Publish distribution 📦 to Test PyPI
+        #   uses: pypa/gh-action-pypi-publish@master
+        #   with:
+        #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        #     repository_url: https://test.pypi.org/legacy/
+        # - name: Publish distribution 📦 to PyPI
+        #   if: startsWith(github.ref, 'refs/tags')
+        #   uses: pypa/gh-action-pypi-publish@master
+        #   with:
+        #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ twine
 numpy
 wheel
 cibuildwheel
+auditwheel


### PR DESCRIPTION
I wasn't able to get TravisCI to work very well for this, but it wasn't
difficult to switch to GitHub actions. This seems to build wheels for
Windows, macOS, and Ubuntu just fine.

To get the wheels in PyPI (see #67), I think we will just need to set
the environment variables `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` and
uncomment the last few steps. Then new releases and tags should be
automatically built and sent to PyPI.

We could also switch (or add) a trigger for releases if preferred:

```
on:
  release:
    types: [created]
```

See https://github.com/swenson/sequitur-g2p/runs/2614119860?check_suite_focus=true for an example successful build.