### PR TITLE
Build linux wheels with manylinux1 Docker image

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -23,10 +23,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - if: ${{ matrix.os == 'ubuntu-20.04' }}
+
+      # TODO: support non-x86_64 platforms
+      - if: ${{ (matrix.os == 'ubuntu-20.04') && (matrix.python-version == '3.6') }}
         run: |
-          wget -O - https://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz | tar xzf -
-          cd swig-4.0.1 && ./configure --without-pcre && make && sudo make install
+          wget -O - https://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz | tar xzf - &&
+          docker run --rm -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/travis/build-wheels.sh
+
       - if: ${{ matrix.os == 'windows-latest' }}
         run: |
           choco install swig
@@ -34,21 +37,24 @@ jobs:
         run: |
           brew update
           brew install swig
-      - run: python -m pip install build
-      - run: pip install -r requirements.txt
-      - run: pip install -r dev-requirements.txt
-      - run: pip install .
-      - run: make travis-test
-      - name: Build a binary wheel and a source tarball
+
+      # windows/mac builds
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: python -m pip install build
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: pip install -r requirements.txt
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: pip install -r dev-requirements.txt
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: pip install .
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: make travis-test
+      - if: ${{ matrix.os != 'ubuntu-20.04' }}
+        name: Build a binary wheel and a source tarball
         run: python -m build --sdist --wheel --outdir dist/ .
-      - run: ls -alR dist/
+
+      - run: ls -alR dist/ || true
         shell: bash {0}
-        ##    # TODO: auditwheel doesn't like our compiler; need to switch to Docker
-        ##  - if: ${{ matrix.os == 'ubuntu-20.04' }}
-        ##    run: |
-        ##       for whl in dist/sequitur*.whl; do
-        ##         auditwheel repair "$whl" --plat manylinux1_x86_64 -w dist/;
-        ##       done
         ##  - name: Publish distribution 📦 to Test PyPI
         ##    uses: pypa/gh-action-pypi-publish@master
         ##    with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default:	build
 
-PYTHON	= python
+PYTHON	?= python
 
 build:
 	$(PYTHON) setup.py build
@@ -10,7 +10,7 @@ build-py:
 .PHONY:	build
 
 # note the test won't probably work well for python3
-travis-test:	
+travis-test:
 	$(PYTHON) test_mGramCounts.py		;\
 #	$(PYTHON) test_SparseVector.py		;\
 #	$(PYTHON) test_LanguageModel.py		;\
@@ -54,4 +54,3 @@ TARGETS	= \
 	_sequitur_.so sequitur_.py	\
 	Evaluation.py  Minimization.py SequenceModel.py sequitur.py g2p.py \
 	misc.py tool.py
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ numpy
 wheel
 cibuildwheel
 auditwheel
+cryptography<3.4

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,31 +1,31 @@
-#!/bin/bash                                                                        
+#!/bin/bash
 # Copyright (c) 2019, Johns Hopkins University ( Yenda Trmal <jtrmal@gmail.com> )
 # License: Apache 2.0
 
-# Begin configuration section.  
+# Begin configuration section.
 # End configuration section
-set -e -o pipefail 
+set -e -o pipefail
 set -o nounset                              # Treat unset variables as an error
 set -x
 
-#yum install -y curl
-#yum install -y wget
+cd /io/swig-4.0.1
+./configure --without-pcre && make && make install
 
-#wget https://downloads.sourceforge.net/swig/swig-4.0.1.tar.gz
-#tar xzf swig-4.0.1.tar.gz
-
-(cd /io/swig-4.0.1; ./configure --without-pcre && make && make install) || exit 1
+cd /io
 
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
-  (cd /io; make clean)
-    "${PYBIN}/pip" install -r /io/dev-requirements.txt
-    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+for PYBIN in /opt/python/cp3*/bin; do
+    $PYBIN/pip install --upgrade pip
+    $PYBIN/pip install -r requirements.txt
+    $PYBIN/pip install -r /io/dev-requirements.txt
+    $PYBIN/pip install .
+    PYTHON=$PYBIN/python make travis-test
+    $PYBIN/python -m build --sdist --wheel --outdir dist/ .
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/sequitur*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+for whl in dist/sequitur*.whl; do
+    auditwheel repair "$whl" --plat $PLAT -w /io/dist/
 done
 
 # Install packages and test
@@ -33,4 +33,3 @@ done
 #    "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
 #    (cd "$HOME"; "${PYBIN}/nosetests" pymanylinuxdemo)
 #done
-


### PR DESCRIPTION
For Python 3.5+

This only supports x86_64 at the moment. We should be able to build for
i686, aarch64, etc. in the future.

 We pin `cryptography` to avoid having to install a Rust compiler.