### PR TITLE
fix: Fixed print function incompatibility with Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Sequitur G2P
 ============
 
-A trainable Grapheme-to-Phoneme converter. This fork should be compatible with Python2.7
+A trainable Grapheme-to-Phoneme converter.
 
 Introduction
 ------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Sequitur G2P
 ============
 
-A trainable Grapheme-to-Phoneme converter.
+A trainable Grapheme-to-Phoneme converter. This fork should be compatible with Python2.7
 
 Introduction
 ------------

--- a/g2p.py
+++ b/g2p.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 """
 Grapheme-to-Phoneme Conversion
 


### PR DESCRIPTION
Python 2.7  seems to not have file= in print function
Simply adding from __future__ import print_function , solves this problem. I hope this is valid @jtrmal 
Fixed #89  