### PR TITLE
fix: do not include <sys/cdefs.h> (#99)

### DIFF
--- a/Assertions.hh
+++ b/Assertions.hh
@@ -28,8 +28,11 @@
 #ifndef _ASSERTIONS_H
 #define _ASSERTIONS_H
 
+#ifndef __STRING
 #define STR(x) #x
 #define __STRING(x) STR(x)
+#endif
+
 #ifdef _MSC_VER
 #define __attribute__(x)
 #endif

--- a/Assertions.hh
+++ b/Assertions.hh
@@ -28,12 +28,10 @@
 #ifndef _ASSERTIONS_H
 #define _ASSERTIONS_H
 
-#ifndef _MSC_VER
-#include <sys/cdefs.h>
-#else
-#define __attribute__(x)
 #define STR(x) #x
 #define __STRING(x) STR(x)
+#ifdef _MSC_VER
+#define __attribute__(x)
 #endif
 #include <iostream>
 


### PR DESCRIPTION
Remove unnecessary use of private glibc header, allows compilation with other libcs, e.g. MUSL on Alpine Linux.