### PR TITLE
fix: include necessary files in source distribution (#98)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include dev-requirements.txt
+include requirements.txt
+recursive-exclude .github *
+recursive-exclude .gitignore *
+recursive-exclude appveyor *
+recursive-exclude travis *
+exclude MANIFEST.in


### PR DESCRIPTION
Add a MANIFEST.in so that all necessary files will show up in the source distribution.

Tested with `python -m build` - suggest using this to build wheels as it will uncover problems like this.